### PR TITLE
Bump PAX version references to purview-v1.11.14 (SharePoint path docs)

### DIFF
--- a/1. SharePoint/azure-container/README.md
+++ b/1. SharePoint/azure-container/README.md
@@ -62,7 +62,7 @@ to be baked into an image:
    ```powershell
    ./Deploy-PAXAcaJob.ps1 `
        -SubscriptionId 'xxx' -ResourceGroup 'rg-pax' -EnvironmentName 'cae-pax' `
-       -JobName 'aibv-sharepoint-daily' -AcrName 'paxacr' -ImageTag '1.11.6' `
+       -JobName 'aibv-sharepoint-daily' -AcrName 'paxacr' -ImageTag '1.11.14' `
        -ManagedIdentityResourceId '/subscriptions/.../userAssignedIdentities/uai-aibv' `
        -ManagedIdentityClientId '<uami-client-id>' `
        -BootstrapLogStorageAccount 'aibvbootstraplogs' `
@@ -82,6 +82,13 @@ to be baked into an image:
 Because PAX emits AIBV directly, the in-container flow is a **single step**
 (PAX → SharePoint) rather than the old two-step (PAX → v4.0.0 processor →
 SharePoint).
+
+> **Pin `-ImageTag '1.11.14'` or newer.** Earlier `purview-v1.11.x` container
+> builds had a bug where the Agent 365 catalog CSV was generated but not
+> uploaded to a SharePoint (or Fabric/OneLake) `-OutputPath`. Fixed in
+> [`purview-v1.11.14`](https://github.com/microsoft/PAX/releases/tag/purview-v1.11.14).
+> Local-output runs via this repo's [`../scripts/Run-PAX-AIBV.ps1`](../scripts/Run-PAX-AIBV.ps1)
+> wrapper were never affected — the bug is remote-output-only.
 
 > [!WARNING]
 > **Permissions differ from the app-registration path — decide this before

--- a/1. SharePoint/scripts/Run-PAX-AIBV.ps1
+++ b/1. SharePoint/scripts/Run-PAX-AIBV.ps1
@@ -33,7 +33,10 @@
   this run's own -Auth mode, so it works unattended - no separate interactive
   sign-in. Requires the app's admin-consented Application permissions
   CopilotPackages.Read.All + Application.Read.All, and an Agent 365 licence in the
-  tenant (a missing licence returns 403).
+  tenant (a missing licence returns 403). (Tested with PAX purview-v1.11.14;
+  v1.11.14 additionally fixes remote-output upload of the catalogue CSV to
+  SharePoint / Fabric-OneLake destinations - local-output runs via this wrapper
+  were never affected.)
 
 .PARAMETER Auth
   PAX auth mode. Default: AppRegistration.


### PR DESCRIPTION
Doc-only bump reflecting [PAX `purview-v1.11.14`](https://github.com/microsoft/PAX/releases/tag/purview-v1.11.14).

**What changed in PAX v1.11.14** — two remote-output delivery fixes. No new switches, no schema changes:
- Agent 365 catalog CSV is now actually uploaded to SharePoint / Fabric-OneLake destinations (previously generated but not delivered).
- Custom-named per-stream output files land at their own destinations (not the primary output location).

**What this PR changes** — docs only, no script logic:
- `1. SharePoint/azure-container/README.md`: bumps the `-ImageTag` example from `1.11.6` to `1.11.14` and adds a callout explaining why to pin.
- `1. SharePoint/scripts/Run-PAX-AIBV.ps1`: annotates the `-IncludeAgent365Info` docstring with the v1.11.14 fix context.

**Not affected** — local-output runs via `Run-PAX-AIBV.ps1` were never subject to the bug (remote-output only). The container/SharePoint deploy path is the one that benefits.

Mirrors `d902f7a` merged to Keithland89/main.