### PR TITLE
docs(fabric): document pre-configured Import incremental refresh

### DIFF
--- a/2. Fabric/README.md
+++ b/2. Fabric/README.md
@@ -122,6 +122,12 @@ Lake works without cross-capacity overhead.
 
 In the Service: dataset **Settings -> Data source credentials** -> sign in to the SQL endpoint, then
 enable **Scheduled refresh** on a cadence that matches your notebook schedule.
+
+> **Incremental refresh is pre-configured.** The template ships with an Import-mode incremental-refresh
+> policy on the `Chat + Agent Interactions (Audit Logs)` fact table (rolling 12-month window, last
+> ~7 days re-queried each run), so the first refresh loads history once and every scheduled refresh
+> after that only appends recent days. It needs a **Premium / PPU / Fabric** capacity. To change the
+> window - or to use **Direct Lake** instead - see [`docs/INCREMENTAL-REFRESH.md`](docs/INCREMENTAL-REFRESH.md).
 </details>
 
 ## Optional sources
@@ -258,7 +264,7 @@ CSVs upstream? The [`../1. SharePoint/`](../1.%20SharePoint/) path consumes them
 | `Login failed` / `cannot open database` (Power BI) | The SQL endpoint host or database name is wrong - recheck the Lakehouse settings page. |
 | `the key didn't match any rows` | A notebook ran against the wrong Lakehouse - pin your Lakehouse as default and re-run. |
 | All users show "Unlicensed" | The licensed-users notebook hasn't run yet, or its report period is too narrow (`REPORT_PERIOD = 'D30'`). |
-| Refresh slow (over a minute) | Dataset is in Import mode - put the workspace on a Fabric capacity and convert to **Direct Lake**. |
+| Refresh slow (over a minute) | Import mode re-imports everything each run. The template ships with **incremental refresh** pre-configured (first load is full, then only recent days) - it needs a Premium/PPU/Fabric capacity; see [`docs/INCREMENTAL-REFRESH.md`](docs/INCREMENTAL-REFRESH.md). For the fastest option on Fabric, convert to **Direct Lake**. |
 
 </details>
 
@@ -266,6 +272,7 @@ CSVs upstream? The [`../1. SharePoint/`](../1.%20SharePoint/) path consumes them
 
 - **Roles & permissions (all sources):** [`docs/PERMISSIONS.md`](docs/PERMISSIONS.md)
 - **Table schemas:** [`docs/DATA-DICTIONARY.md`](docs/DATA-DICTIONARY.md)
+- **Incremental refresh (Import mode):** [`docs/INCREMENTAL-REFRESH.md`](docs/INCREMENTAL-REFRESH.md)
 - **Optional sources in depth:** [`docs/OPTIONAL-SOURCES.md`](docs/OPTIONAL-SOURCES.md)
 - **Cowork / Work IQ consumption, step by step:** [`flows/COST-CONSUMPTION-SETUP.md`](flows/COST-CONSUMPTION-SETUP.md) (start here) · [`flows/COST-CONSUMPTION.md`](flows/COST-CONSUMPTION.md) (schema + model wiring)
 - **PPAC credit consumption (Studio build):** [`Fabric + Copilot Studio/CREDIT-CONSUMPTION-SETUP.md`](../3.%20Fabric%20Extended/Fabric%20+%20Copilot%20Studio/CREDIT-CONSUMPTION-SETUP.md)

--- a/2. Fabric/docs/INCREMENTAL-REFRESH.md
+++ b/2. Fabric/docs/INCREMENTAL-REFRESH.md
@@ -1,0 +1,77 @@
+# Incremental refresh (Import mode)
+
+The `ValueLens - Fabric.pbit` template ships with **incremental refresh already configured** on the
+audit-interactions fact table, so you don't have to set it up. This note explains what it does, what it
+needs, and how to change it.
+
+## What's pre-configured
+
+The fact table **`Chat + Agent Interactions (Audit Logs)`** (sourced from `copilot_interactions_parsed`)
+carries an Import-mode incremental-refresh policy:
+
+| Setting | Value | Effect |
+|---|---|---|
+| Archive / rolling window | **12 months** | Only the last 12 months are kept; older rows drop off automatically. |
+| Incremental window | **last ~7 days** | Only the most recent days are re-queried on each refresh. |
+| Change detection | Rolling window (no polling) | Recent days are re-imported wholesale; older partitions are stored and never re-queried. |
+
+Two auto-managed parameters, **`RangeStart`** and **`RangeEnd`** (DateTime), drive the partition filter
+`CreationDate >= RangeStart and CreationDate < RangeEnd`. **Leave them alone** - Power BI sets them per
+partition at refresh time. Don't delete, rename, or hard-code them.
+
+## What to expect
+
+- **The first refresh is a full load** of the whole 12-month window - expect it to take a while (tens of
+  minutes on a large tenant). This is normal and happens once.
+- **Every scheduled refresh after that only appends the last ~7 days**, so it's much faster and stays
+  roughly constant no matter how much history has accumulated.
+- The ~7-day incremental window overlaps your daily audit pull, so a missed or late run self-heals on the
+  next refresh.
+
+## Requirements
+
+- **A Premium, Premium-Per-User (PPU), or Fabric capacity workspace.** Incremental refresh does **not**
+  run on a shared / Pro workspace - publish to a capacity-backed workspace.
+- **Import storage mode** (the template's default). See *Import + incremental vs Direct Lake* below.
+- Valid **data-source credentials** on the dataset (**Settings -> Data source credentials**). If they're
+  missing you'll see *"Scheduled refresh is disabled because at least one data source does not have
+  credentials"* - sign in to the SQL endpoint, then re-enable scheduled refresh.
+
+## Changing the window
+
+Do this in Power BI Desktop **before** you publish (or re-publish after changing):
+
+1. In **Report** / **Model** view, right-click the **`Chat + Agent Interactions (Audit Logs)`** table ->
+   **Incremental refresh**.
+2. Adjust **"Archive data starting ... before refresh date"** (the rolling window - e.g. 6, 12, or 24
+   months) and **"Incrementally refresh data starting ... before refresh date"** (the re-queried window -
+   e.g. 3, 7, or 10 days).
+3. **Apply**, then **Publish**. The next refresh in the Service re-partitions to match.
+
+> A shorter rolling window (e.g. 6 months) = a smaller model and a faster first load. A longer incremental
+> window = more self-healing overlap but slightly slower refreshes. **12 months / 7 days** is a sensible
+> default for most tenants; 6-12 months of look-back covers the majority of adoption reporting.
+
+## Import + incremental vs Direct Lake
+
+Both keep refreshes cheap; pick based on where your data lives:
+
+| | Import + incremental refresh (default) | Direct Lake |
+|---|---|---|
+| Where it runs | Any SQL endpoint (Fabric, Databricks, Synapse, Azure SQL) | **Fabric only** - reads Delta straight from OneLake |
+| Data movement | Imports recent partitions on a schedule | No import - queries the Lakehouse live |
+| Best when | Non-Fabric backends, or you want a self-contained dataset | Model + Lakehouse are on the **same Fabric capacity** |
+| Setup | Already configured here | Recreate the model as Direct Lake over the Lakehouse |
+
+If your Lakehouse and dataset sit on the same Fabric capacity, Direct Lake is the fastest option (no
+import at all). Everywhere else, the shipped **Import + incremental refresh** is the right default.
+
+## Notes
+
+- Incremental refresh applies to the **audit-interactions** fact table (the large, continuously growing
+  feed). The current-state snapshot tables (org data, licensed users, credit, Agents 365) are small and
+  refresh in full each run - they don't need a policy.
+- This is the **Power BI dataset** incremental refresh. It's separate from the **notebook** high-water-mark
+  ingest (`MODE=incremental` in the audit ingester), which controls how much data lands in the Lakehouse.
+  The two complement each other: the notebook keeps the Lakehouse current, and incremental refresh keeps
+  the dataset refresh cheap. See [`INGESTION-STRATEGY.md`](INGESTION-STRATEGY.md).


### PR DESCRIPTION
## What & why

The Fabric template (`ValueLens - Fabric.pbit`) ships with an **Import-mode incremental-refresh policy already configured** on the `Chat + Agent Interactions (Audit Logs)` fact table, but that behaviour was **undocumented**. Users saw a slow (~40 min) first refresh followed by faster (~30 min) subsequent runs with no explanation, and no guidance on the Premium/PPU/Fabric capacity requirement or how to change the window.

## Changes

- **New:** `2. Fabric/docs/INCREMENTAL-REFRESH.md` — explains the pre-configured policy (12-month rolling window, ~7-day incremental window, auto-managed `RangeStart`/`RangeEnd`), what to expect on first vs subsequent refreshes, the capacity requirement, how to change the window in Power BI Desktop, and Import+incremental vs Direct Lake.
- **`2. Fabric/README.md`** — three cross-links to the new doc (Step 5, the Troubleshooting slow-refresh row, and the Reference list). *(Follow-up commit.)*

No template or data changes — documentation only.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>