### PR TITLE
docs(fabric): trim StudioLens content from ValueLens guidance (No-Studio scope)

### DIFF
--- a/2. Fabric/docs/DATA-DICTIONARY.md
+++ b/2. Fabric/docs/DATA-DICTIONARY.md
@@ -13,6 +13,11 @@ Because the schema is identical, the report, every measure, and all downstream M
 producer (notebook or script) is "compatible" **iff** the Delta table / CSV it writes exposes the
 exact column names below (casing and spaces matter).
 
+> **Base (No-Studio) build.** This build reads three **core** sources plus a few standard **optional**
+> sources. Copilot Studio agent-transcript analytics (the `agent_*` Dataverse tables) and the PPAC
+> per-agent / per-user message-credit tables are **not** part of this build — they live in the separate
+> [Fabric + Copilot Studio](../../3.%20Fabric%20Extended/Fabric%20+%20Copilot%20Studio/) template.
+
 ---
 
 ## Tier model — core vs optional
@@ -27,22 +32,12 @@ template never breaks. See `OPTIONAL-SOURCES.md` for the `EmptyTable` + `try…o
 | 2 | Copilot Licensed | `copilot_licensed_users` | **Core** | `Copilot_Licensed_Users_Direct_Ingester` | `GetCopilotUsers*` |
 | 3 | Chat + Agent Org Data | `copilot_org_data` | **Core** | `Copilot_Org_Data_Direct_Ingester` | `Get-EntraOrgData*` |
 | 4 | Agents 365 | `agents_365` | *Optional* | `Copilot_Agent365_Lander` | `Get-Agents365Registry` |
-| 5 | ProductFeedback | `user_feedback` | *Optional* | `Copilot_Agent_Transcript_Parser` (`build_feedback`) | OCV feedback CSV |
-| 6 | Agent Sessions | `agent_sessions` | *Optional* (Dataverse) | `Copilot_Agent_Transcript_Parser` | n/a |
-| 7 | Agent Turns | `agent_turns` | *Optional* (Dataverse) | `Copilot_Agent_Transcript_Parser` | n/a |
-| 8 | Agent Errors | `agent_errors` | *Optional* (Dataverse) | `Copilot_Agent_Transcript_Parser` | n/a |
-| 9 | Agent Sub-Agent Calls | `agent_subagents` | *Optional* (Dataverse) | `Copilot_Agent_Transcript_Parser` | n/a |
-| 10 | Agent Catalogue | `agent_catalogue` | *Optional* (Dataverse) | `Copilot_Agent_Transcript_Parser` | n/a |
-| 11 | Agent Performance | `agent_performance` | *Optional* (Dataverse) | `Copilot_Agent_Transcript_Parser` | n/a |
-| 12 | Credit Consumption (Tenant) | `credit_consumption_tenant` | *Optional* (billing) | `Copilot_Credit_Consumption_Ingester` | n/a |
-| 13 | Copilot Cost Consumption | `copilot_cost_consumption` | *Optional* (billing) | `Copilot_Cost_Consumption_Ingester` | SharePoint CSV (`Cost Consumption File`) |
+| 5 | ProductFeedback | `user_feedback` | *Optional* | OCV feedback export (`build_feedback`) | OCV feedback CSV |
+| 6 | Copilot Cost Consumption | `copilot_cost_consumption` | *Optional* | `Copilot_Cost_Consumption_Ingester` | SharePoint CSV (`Cost Consumption File`) |
 
-> **Row 12 (PPAC credit consumption)** is the **Power Platform Admin Center** tenant-level Copilot
-> Studio message-credit build, now a [Fabric + Copilot Studio](../../3.%20Fabric%20Extended/Fabric%20+%20Copilot%20Studio/)
-> add-on. The tenant-grain table remains in the base PBIT transitionally (gated by `Enable_AgentConsumption`);
-> the per-agent and per-user credit grains, the ingester notebook, and the setup guide live only with the
-> Studio Extended template. Row 13 (`copilot_cost_consumption`)
-> is the **MAC Cowork / Work IQ** consumption build that stays standard across all templates.
+> **Cost consumption (row 6)** is the **Microsoft 365 Admin Center → Copilot → Cost management** export
+> (Cowork / Work IQ credits). It's standard across all templates. The **PPAC** message-credit tables
+> (per-agent / per-user) are a Studio add-on — see the Extended build.
 
 All other model tables (Calendar, legends, ranking/summary, glossary, value maps, etc.) are
 **calculated/DAX or static** — they have no external source and are version-independent.
@@ -98,12 +93,8 @@ id, PersonId, displayName, Organization, JobTitle, companyName,
 officeLocation, city, country, accountEnabled, managerUPN
 ```
 
-**Two join keys (important):**
-- `PersonId` = **userPrincipalName (UPN)** — used by the **Audit Logs** path (`Audit_UserId → PersonId`).
-- `id` = **AAD object id** — used by the **Dataverse** path (`Agent Sessions.user_id_hash → id`), because
-  the transcript parser emits the user's `aadObjectId`, not the UPN. The producer must populate `id`
-  (Graph `/users` `id`) or the credit-by-organization breakdown silently shows 100% for every org
-  (dangling relationship → Organization filter never reaches Agent Sessions).
+**Join key:** `PersonId` = **userPrincipalName (UPN)** — used by the **Audit Logs** path
+(`Audit_UserId → PersonId`). `id` (AAD object id) is also emitted for downstream joins.
 
 ---
 
@@ -141,13 +132,11 @@ that **auto-detects** the GUID from whatever the export provides — it picks th
 `Entra Agent ID → EntraAgentId → Agent ID → Bot Id` (and common variants). The customer never has to
 create or populate a column by hand; a non-matching GUID simply does not join (no false links). Until
 an export carries Entra GUIDs, custom agents still resolve by name.
-**Dataverse path:** not applicable — it keys agents on `botSchemaName` (transcript trace), not audit `AgentId`.
 
 ### 5. `user_feedback` — Product Feedback (OCV export)
-**Not** a Dataverse source — it is an OCV/Viva feedback **CSV** dropped at
-`Files/copilot_transcripts/feedback.csv`, parsed by `build_feedback()`. The dashboard's
-`ProductFeedback` table renames the OCV space-named columns. The empty placeholder now emits the
-**full superset** (fixed) so a missing/partial export cannot break refresh:
+An OCV/Viva feedback **CSV** dropped at `Files/copilot_transcripts/feedback.csv`, parsed by
+`build_feedback()`. The dashboard's `ProductFeedback` table renames the OCV space-named columns. The
+empty placeholder emits the **full superset** so a missing/partial export cannot break refresh:
 
 ```
 Feedback Id, Comment, Translated Comment, Comment Language,
@@ -160,78 +149,12 @@ Date Submitted Date, Sentiment
 ```
 *(Recommended: also add `MissingField.Ignore` to the model's `Table.RenameColumns` so partial OCV exports are tolerant.)*
 
-### 6–11. Dataverse agent tables (from `conversationtranscripts`)
-Produced by `Copilot_Agent_Transcript_Parser` (`SOURCE_MODE='dataverse'`, `AUTH_MODE='sp'`).
-**Note:** Fabric `notebookutils.getToken` cannot mint a Dataverse token — the notebook must use an
-**app-registration service principal** added as an **Application User** (e.g. *Bot Transcript Viewer*
-role) in each environment. When Dataverse is not configured these six tables load empty.
-
-**`agent_sessions`** (31)
-```
-conversation_id, session_start_utc, session_duration_ms, user_id_hash,
-primary_agent_schema, agent_name, agent_id,
-connected_agent_schemas, connected_agent_count,
-msg_count, user_msg_count, bot_msg_count, plan_step_count,
-total_displayed_cost, total_latency_ms,
-knowledge_searched, knowledge_answered, knowledge_sources_count, grounding_source,
-error_count, first_error_code,
-feedback_offered_count, feedback_submitted, feedback_verdict, feedback_comment,
-first_user_prompt,
-session_outcome_explicit, session_outcome_reason_explicit,
-is_authenticated, is_returning_user, primary_topic_derived
-```
-> `primary_agent_schema` is the agent **join key** (→ `agent_catalogue.agent_schema`). It is
-> resolved from the most reliable signal available — Dataverse bot lookup, then bot-message
-> `from.name`/`from.id`, then user-message `recipient`, then orchestration trace, then the
-> transcript `name` — so single-agent transcripts (no orchestration trace) are still attributed.
-> `agent_name` / `agent_id` carry the real resolved bot display name and id for richer binding.
-**`agent_turns`** (17)
-```
-conversation_id, turn_id, turn_timestamp_utc, turn_role, turn_channel,
-from_user_hash, text_preview_500, text_length,
-intent_title, intent_id, intent_score,
-knowledge_searched, knowledge_answered, knowledge_sources,
-feedback_offered, feedback_verdict, feedback_comment
-```
-**`agent_errors`** (6)
-```
-conversation_id, error_timestamp_utc, error_code, error_sub_code, error_message, is_user_error
-```
-**`agent_subagents`** (8)
-```
-conversation_id, invocation_timestamp_utc, event_type,
-parent_agent_schema, connected_agent_schema, dialog_schema,
-user_id_hash, plan_step_id
-```
-**`agent_catalogue`** (3, +`source_environments` when `TAG_ENVIRONMENT=True`)
-```
-agent_schema, agent_display_name, agent_class
-```
-**`agent_performance`** (39)
-```
-ConversationTranscriptId, ConversationStartTime, SchemaVersion, BotName, BotId,
-AADTenantId, BatchId, SessionStartTimeUtc, SessionEndTimeUtc,
-SessionType, SessionOutcome, TurnCount, OutcomeReason, ImpliedSuccess,
-LastUserIntentId, IsDesignMode, Locale,
-UserMessageCount, BotMessageCount, TotalMessageCount,
-FirstUserMessage, LastUserMessage, FirstBotMessage, LastBotMessage,
-TopicsTriggered, TopicCount, PrimaryTopic,
-DurationSeconds, AverageLatencyMs,
-Var_ESS_UserContext_UPN, Var_ESS_Message_Disclaimer,
-Var_ESS_UserContext_RefreshInterval_Hours, Var_ESS_UserContext_Conversation_Initialized,
-AllVariables, TotalActivityCount, TraceActivityCount, EventActivityCount,
-StatusCode, StateCode
-```
-*When `TAG_ENVIRONMENT=True`, the five fact tables also carry `source_environment` (and
-`agent_catalogue` carries `source_environments`).*
-
-### 13. `copilot_cost_consumption` — Copilot credit usage (MAC Cost management export)
+### 6. `copilot_cost_consumption` — Copilot credit usage (MAC Cost management export)
 Produced by `Copilot_Cost_Consumption_Ingester` from the **Microsoft 365 Admin Center → Copilot →
 Cost management** per-user CSV export (export-only; no API). **Auto-detects two export shapes** and maps
 both to one unified contract: the **surface split** (`Cowork`/`WorkIQ`/`Other` credits) and the
 **per-user usage** export (monthly limit / used / % used / sessions). This is the **only**
-customer-pullable place Cowork/WorkIQ credits appear. **Additive**, not a replacement, to the PPAC
-`credit_consumption_*` (MCSMessages) tables. Gated by `Enable_CostConsumption`; both Fabric and
+customer-pullable place Cowork/WorkIQ credits appear. Gated by `Enable_CostConsumption`; both Fabric and
 SharePoint paths produce the identical contract. Header matching is **case-insensitive**.
 
 ```
@@ -261,20 +184,4 @@ unmatched users surface under an **"(Unattributed)"** organization bucket. See
 | A | `user_feedback` | Empty placeholder had 6 cols; `Table.RenameColumns` expects 17 → refresh broke when no feedback.csv | **Fixed** in notebook (full superset). Also add `MissingField.Ignore` in model. |
 | B | `copilot_licensed_users` | Producer writes underscore names; model variant lists only have spaced/camel forms → UPN + licence load null | **Fixed** — underscore variants added to model |
 | C | `agents_365` | Fabric model read a SharePoint URL | **Fixed** — `Copilot_Agent365_Lander` lands `dbo.agents_365`; table now `FabricTable` + `Enable_Agent365` |
-| D | Audit/Licensed/Org core M | Staged from an older snapshot assuming RAW audit JSON (unconditional adds + `Json.Document`) → "field already exists" on pre-flattened producer output | **Fixed** — re-based on the §7-fixed versions (17 `HasColumns` guards, conditional parse) |
-| E | `Agent Sessions → Org` (credits) | Join `user_id_hash → id` dangled because org producer never emitted `id`; credit-by-org showed 100% per org | **Fixed (producer)** — org ingester now emits Graph `id` (AAD objectId). Requires org re-land. |
-
-## Known limitation — cross-environment / cross-tenant user identity
-
-The **Dataverse** agent tables key on the user's **AAD objectId** (`user_id_hash`), while **Org** data is
-Entra from *this* tenant. These only reconcile when the **transcripts and the Entra directory describe
-the same users in the same tenant**. If agents are published in a **different environment/tenant** (common
-in demos), the objectIds won't exist in the org table and credit-by-organization will show no/!00%
-breakdown — this is a **data alignment** issue, not a model bug.
-
-**Recommended robust design for the customer template** (not breaking, degrades cleanly):
-1. Keep the objectId join (`user_id_hash → id`) as primary.
-2. Optionally have the parser also emit the **UPN** (`user_upn`) when the transcript activity carries it,
-   and add a fallback relationship `user_upn → PersonId_Normalized`.
-3. Surface unmatched credit rows under an **"(Unmapped)"** organization rather than letting them silently
-   inflate every org's share — so a key mismatch is *visible*, never misleading.
+| D | Audit/Licensed/Org core M | Staged from an older snapshot assuming RAW audit JSON (unconditional adds + `Json.Document`) → "field already exists" on pre-flattened producer output | **Fixed** — re-based on the fixed versions (17 `HasColumns` guards, conditional parse) |

--- a/2. Fabric/docs/INGESTION-STRATEGY.md
+++ b/2. Fabric/docs/INGESTION-STRATEGY.md
@@ -1,93 +1,78 @@
-# Ingestion: merge strategies, scalability & versioning
+# Ingestion: load strategy, scale & versioning
 
 Guidance for running the Fabric path in production — how to load each source (overwrite vs
-append vs merge), what to expect on scale, and how to pin a stable build.
+append), what to expect at scale, and how to pin a stable build.
+
+This is the base **No-Studio** build: three core sources — **audit logs**, **licensed users**, and
+**org data**. Optional add-ons (Cowork / Work IQ consumption, product feedback, Agents 365) follow the
+same rules; Copilot Studio agent-transcript analytics and PPAC message-credit tables live in the
+separate [Fabric + Copilot Studio](../../3.%20Fabric%20Extended/Fabric%20+%20Copilot%20Studio/) build.
 
 ---
 
-## 1. Recommended load strategy per source
+## 1. Load strategy per source
 
-Each ingester supports `WRITE_MODE` = `overwrite` | `append` | `merge`. Pick per source:
+Each ingester supports `WRITE_MODE` = `overwrite` | `append` | `merge`. For the core sources:
 
 | Source / table | Recommended | Why |
 |---|---|---|
-| **Conversation transcripts** → `agent_sessions/turns/errors/subagents/catalogue/performance` (`Copilot_Agent_Transcript_Parser`) | **`merge`** for incremental day-by-day; **`overwrite`** for a one-shot full reload | Each fact table has a stable natural key, so `merge` upserts slices with **no duplicates and no gaps**. Keys: sessions=`conversation_id`, turns=`turn_id`, errors=`conversation_id+error_timestamp_utc+error_code`, subagents=`conversation_id+invocation_timestamp_utc+connected_agent_schema+plan_step_id`, performance=`ConversationTranscriptId`, catalogue=`agent_schema`. In multi-environment runs the environment is auto-added to the key so the same conversation id from two envs can't collide. |
-| **Audit log** → `Copilot_Interactions_Parsed` (`Copilot_Audit_Log_Direct_Ingester`) | **`append`** day-by-day (the notebook windows the range and streams pages); **`overwrite`** for a fresh snapshot | Audit records are immutable events keyed by `RecordId`. Append each day's slice. If you need exactly-once on re-runs, dedupe on `RecordId` downstream (or switch to a keyed merge). |
-| **Org / people** (`Copilot_Org_Data_Direct_Ingester` or the Graph→SharePoint flow) | **`overwrite`** | It's a current-state snapshot of users, not an event stream — replace it each refresh. |
-| **Licensed users** (`Copilot_Licensed_Users_Direct_Ingester`) | **`overwrite`** | Current-state snapshot. |
-| **Credit consumption** (agent / user / tenant) | **`overwrite`** per billing export | The portal exports are point-in-time totals for the period. Overwrite with the latest export; the `Billing Period` measure states the window covered. (If you instead accumulate daily slices, use `append` and slice by `Usage_Date`.) |
-| **Agents 365 registry** | **`overwrite`** | Current-state registry snapshot. |
+| **Audit log** → `copilot_interactions_parsed` (`Copilot_Audit_Log_Direct_Ingester`) | **`append`** day-by-day; **`overwrite`** for a fresh snapshot | Audit records are immutable events keyed by `RecordId`. Append each day's slice. For exactly-once on re-runs, dedupe on `RecordId` downstream. |
+| **Licensed users** → `copilot_licensed_users` (`Copilot_Licensed_Users_Direct_Ingester`) | **`overwrite`** | Current-state snapshot of who's licensed — replace it each run. |
+| **Org / people** → `copilot_org_data` (`Copilot_Org_Data_Direct_Ingester`) | **`overwrite`** | Current-state snapshot of users — replace it each run. |
 
-> **Rule of thumb:** *event streams* (transcripts, audit) → **merge/append**; *current-state snapshots*
-> (org, licensed users, credit, agents registry) → **overwrite**.
+> **Rule of thumb:** the audit log is an *event stream* → **append**; the snapshot sources (licensed
+> users, org, and the optional Agents 365 / consumption / feedback exports) → **overwrite**.
 
-### Backfilling 2026 day-by-day
-For "all data since 1 Jan 2026", loop the date window in the **ingester**, not the dashboard:
-- **Audit:** set `LOOKBACK_DAYS` per run and schedule daily with `WRITE_MODE='append'`; the notebook
-  already chunks each run into `CHUNK_HOURS` windows and **retries transient 5xx/429** (see §3).
-- **Transcripts:** run with `LOOKBACK_DAYS = N` and `WRITE_MODE='merge'`; re-running an overlapping
-  window is safe (upsert, no dupes). For the very first full load use `LOOKBACK_DAYS = 0` (all rows).
+### Backfilling history
+For "all data since 1 Jan 2026", loop the date window in the **audit ingester**, not the dashboard:
+set `LOOKBACK_DAYS` per run and schedule daily with `WRITE_MODE='append'`. The notebook already chunks
+each run into `CHUNK_HOURS` windows and **retries transient 5xx/429** (see §3), so a long backfill
+survives Purview throttling. (Graph caps each audit query to a rolling 7-day window, so history is
+built up day-by-day rather than in one shot.)
 
 ---
 
-## 2. Scalability — keep Power Query thin
+## 2. Keep Power Query thin
 
-**Direction: heavy transforms belong in the notebooks (Spark), not Power Query.** The Fabric path is
-designed so the PBIT reads **already-shaped Delta tables** and does only light typing/measures. If a
-refresh is taking minutes, check:
+The Fabric path is built so the PBIT reads **already-shaped Delta tables** and does only light typing
+and measures — the heavy parsing (audit `AuditData` flatten, agent-identity resolution) happens in the
+Spark notebooks. If a refresh is taking minutes:
 
-1. **You're on the Fabric path, not the Dataverse path.** The **Dataverse** companion template parses
-   transcript JSON *inside* Power Query (M) by design — that's fine for small tenants but **not** meant
-   for scale. For large tenants use **`2. Fabric`**, where the Spark notebook does the parsing and PQ
-   stays thin.
-2. **Storage mode.** For large models prefer **Direct Lake** (or Import with incremental refresh) over
-   re-importing everything each run.
-3. **No per-row M expansion.** Avoid `Table.AddColumn` with record/JSON parsing in the PBIT on the
-   Fabric path — that work should already be done in the notebook.
+1. **Prefer incremental refresh or Direct Lake** over re-importing everything each run — see
+   [`INCREMENTAL-REFRESH.md`](INCREMENTAL-REFRESH.md).
+2. **No per-row M expansion.** Don't add record/JSON parsing in the PBIT on the Fabric path — that work
+   belongs in the ingester notebook, so the table you connect to is already flat.
 
-**Already moved to notebooks:** transcript JSON parsing, audit `AuditData` flatten, agent identity
-resolution, topic-ready shaping. **Still in PQ (intentionally light):** header normalisation + typing
-for the CSV sources (org/credit/Agents 365), and the value-model DAX.
-
-> If you see PQ doing real transformation on a large feed, that's the signal to push it into the
-> corresponding ingester notebook and have the PBIT read the resulting Delta table.
+> If you see Power Query doing real transformation on a large feed, push it into the ingester notebook
+> and have the PBIT read the resulting Delta table.
 
 ---
 
 ## 3. Resiliency (already in the build)
 
-- **Audit ingester** now uses a shared `requests.Session` with `urllib3` **Retry**
-  (`429/500/502/503/504`, exponential backoff, honours `Retry-After`) plus an outer retry loop, so
-  transient **504 Gateway Timeouts** during poll/fetch no longer abort the run. The lookback is split
-  into `CHUNK_HOURS` windows with a generous, configurable `MAX_WAIT_MIN_PER_QUERY`, and records are
-  streamed to Lakehouse Files (bounded driver memory).
-- **Transcript parser** writes the heavy raw `content` landing in **`RAW_TABLE_CHUNK_ROWS` (2000)**
-  chunks to stay under `spark.rpc.message.maxSize`; on very large tenants set **`RAW_TABLE = ''`** to
-  skip the optional raw landing entirely (the `agent_*` tables are what the PBIT needs).
-- **Credit (Tenant) dates** parse US-format `Usage_Date` with explicit `"en-US"` culture, so they no
-  longer fail on non-US machine/region locales.
+- **Audit ingester** uses a shared `requests.Session` with `urllib3` **Retry** (`429/500/502/503/504`,
+  exponential backoff, honours `Retry-After`) plus an outer retry loop, so transient **504 Gateway
+  Timeouts** during poll/fetch no longer abort the run. The lookback is split into `CHUNK_HOURS`
+  windows with a configurable `MAX_WAIT_MIN_PER_QUERY`, and records stream to Lakehouse Files (bounded
+  driver memory).
+- **Consumption dates** parse US-format `Usage_Date` with explicit `"en-US"` culture, so they don't
+  fail on non-US machine/region locales.
 
 ---
 
 ## 4. Production: stable build & upgrade path
 
-**Pin a known-good commit.** Build your automation against a specific Git **tag/commit SHA** of this
-repo rather than tracking `main`, so an upstream change can't break a running pipeline. Suggested flow:
+**Pin a known-good commit.** Build your automation against a specific Git **tag / commit SHA** of this
+repo rather than tracking `main`, so an upstream change can't break a running pipeline:
 
-1. Validate a commit in a non-prod workspace (run all ingesters + refresh the PBIT).
+1. Validate a commit in a non-prod workspace (run the ingesters + refresh the PBIT).
 2. Tag it (e.g. `v2026.07-fabric`) and point production at that tag.
-3. To upgrade: diff the new tag's `2. Fabric/notebooks/` and `CHANGELOG`, test in non-prod, then move
-   the tag.
+3. To upgrade: diff the new tag's `2. Fabric/notebooks/`, test in non-prod, then move the tag.
 
-**What's stable now:** the Fabric ingesters + `2. Fabric` PBIT have been validated end-to-end
-(transcripts → six `agent_*` Delta tables; audit → `Copilot_Interactions_Parsed`; credit/org CSVs).
-The output **Delta table contracts** (table + column names) are the integration surface — changes to
-them will be called out so you can upgrade without surprises. Config-cell **parameters** are additive
-where possible.
-
-**Compatibility tips for your automation:**
-- Drive notebooks via parameters (the CONFIG cell is tagged as the pipeline `parameters` cell) — don't
-  fork the notebook body, so upgrades are a definition swap.
+**Compatibility tips:**
+- Drive notebooks via the CONFIG cell (tagged as the pipeline `parameters` cell) — don't fork the
+  notebook body, so upgrades are a definition swap.
 - Keep secrets in **Key Vault** (`notebookutils.credentials.getSecret`), not in the CONFIG cell.
-- Treat the `agent_*` / `Copilot_Interactions_Parsed` schemas as the contract; build dependencies on
-  those, not on intermediate tables like `conversationtranscripts_raw`.
+- Treat the Delta **table + column names** (`copilot_interactions_parsed`, `copilot_licensed_users`,
+  `copilot_org_data`) as the integration contract; build dependencies on those, not on intermediate
+  tables. Contract changes are called out so you can upgrade without surprises.

--- a/2. Fabric/docs/OPTIONAL-SOURCES.md
+++ b/2. Fabric/docs/OPTIONAL-SOURCES.md
@@ -19,11 +19,9 @@ and the measures simply return `0`/blank.
 
 | Parameter | Default | Controls |
 | --- | --- | --- |
-| `Enable_Dataverse` | `"Include"` | the 6 agent tables (`agent_sessions`, `agent_turns`, `agent_errors`, `agent_subagents`, `agent_catalogue`, `agent_performance`) |
-| `Enable_ProductFeedback` | `"Include"` | `user_feedback` (ProductFeedback) |
-| `Enable_Agent365` | `"Include"` | `agents_365` (Agents 365) |
-| `Enable_Consumption` | `"Include"` | the 3 billing tables (`credit_consumption_tenant/agent/user`) — **PPAC credit build; now a [Fabric + Copilot Studio](../../3.%20Fabric%20Extended/Fabric%20+%20Copilot%20Studio/) add-on** (leave `"Exclude"` in the lean build) |
-| `Enable_CostConsumption` | `"Include"` | `copilot_cost_consumption` (Cowork / WorkIQ / Other credits — MAC Cost management export) |
+| `Enable_ProductFeedback` | `"Include"` | `user_feedback` (ProductFeedback — OCV export) |
+| `Enable_Agent365` | `"Include"` | `agents_365` (Agents 365 registry) |
+| `Enable_CostConsumption` | `"Include"` | `copilot_cost_consumption` (Cowork / Work IQ / Other credits — MAC Cost management export) |
 
 Set a toggle to `"Exclude"` to skip that source entirely (no fetch attempt) — useful when a customer
 hasn't licensed/exported it, or to speed up refresh.
@@ -31,14 +29,18 @@ hasn't licensed/exported it, or to speed up refresh.
 > These are **list parameters** offering `"Include"` / `"Exclude"` (they render as a dropdown in
 > *Edit Parameters*), not boolean `true`/`false`.
 
+> **Studio add-ons.** Copilot Studio agent-transcript tables (`Enable_Dataverse`) and PPAC per-agent /
+> per-user message-credit tables (`Enable_Consumption`) belong to the separate
+> [Fabric + Copilot Studio](../../3.%20Fabric%20Extended/Fabric%20+%20Copilot%20Studio/) build, not this one.
+
 ## 3. The per-table wrapper
 
-Each optional table's M entry point is wrapped like this (Agent Sessions shown):
+Each optional table's M entry point is wrapped like this (Product Feedback shown):
 
 ```m
 Promoted =
-    if Enable_Dataverse = "Include"
-    then (try FabricTable("agent_sessions") otherwise EmptyTable({ ...contract columns... }))
+    if Enable_ProductFeedback = "Include"
+    then (try FabricTable("user_feedback") otherwise EmptyTable({ ...contract columns... }))
     else EmptyTable({ ...contract columns... }),
 ```
 
@@ -68,12 +70,12 @@ Promoted =
 
 Before release, confirm a green refresh for each combination (at minimum):
 
-| Dataverse | Product Feedback | Agent 365 | Expected |
+| Product Feedback | Agent 365 | Cost Consumption | Expected |
 | --- | --- | --- | --- |
 | on (data) | on (data) | on (data) | full dashboard |
 | off | off | off | core-only, no errors |
-| on (empty/missing) | on (missing) | on (missing) | empty optional tables, no errors |
-| on (data) | off | on (data) | feedback page blank, rest populated |
+| on (missing) | on (missing) | on (missing) | empty optional tables, no errors |
+| on (data) | on (data) | off | cost page blank, rest populated |
 
 > ⚠️ These M changes must be opened & refreshed once in **Power BI Desktop** to validate (the edits
 > were made directly in TMDL). Desktop will also assign proper lineage on first save.

--- a/2. Fabric/docs/PERMISSIONS.md
+++ b/2. Fabric/docs/PERMISSIONS.md
@@ -30,13 +30,17 @@ One app registration covers all three. Put the client secret in **Azure Key Vaul
 
 | Source | API? | Automated-pull permission | Manual-export role |
 |---|---|---|---|
-| **Agent transcripts** (Dataverse) | ✅ Dataverse Web API | App reg added as an **Application User** in the Dataverse environment, with a security role granting **Read** on the **Conversation Transcript** table (System Customizer, or a custom read-only role). Auth is client-credentials to `{env}/.default` — **no Graph permission needed**. | System Administrator / System Customizer / Environment Maker |
-| **Credit consumption** (Power Platform) | ❌ export-only | None — there is no API. The CSVs are landed by the Power Automate flow (see below), then the ingester notebook reads them. | Global Administrator or Billing Administrator |
-| **Product feedback** (M365 Health) | ❌ export-only | None — there is no API. Landed by the Power Automate flow, then ingested. | Global Administrator or Reports Reader |
+| **Cost consumption** (M365 Admin Center → Copilot → Cost management) | ❌ export-only | None — there is no API. The per-user CSV is exported and landed (Power Automate flow or manually), then the ingester notebook reads it. | Global Administrator or Billing Administrator |
+| **Product feedback** (OCV / M365 Health) | ❌ export-only | None — there is no API. Landed by the Power Automate flow, then ingested. | Global Administrator or Reports Reader |
 | **Agents 365** | export/lander | Lander notebook reads an exported registry CSV. | Global Administrator or Reports Reader (with **AI Admin** in a Frontier-enrolled tenant) |
 
 For the two **export-only** sources, the only "permission" to automate is the flow's **OneLake write**
 right (next section) — the data itself must be exported by an admin (or a scheduled portal export) first.
+
+> **Studio add-ons.** Copilot Studio agent-transcript (Dataverse) analytics and PPAC per-agent /
+> per-user message-credit consumption need extra grants (a Dataverse **Application User** with read on
+> the **Conversation Transcript** table; Power Platform admin export). Those are covered in the separate
+> [Fabric + Copilot Studio](../../3.%20Fabric%20Extended/Fabric%20+%20Copilot%20Studio/) build.
 
 ---
 
@@ -54,8 +58,7 @@ right (next section) — the data itself must be exported by an admin (or a sche
 ## Quick "who do I ask?" summary
 
 - **Just the core dashboard:** one Entra app reg (3 Graph perms, admin-consented) + Contributor on the workspace.
-- **+ Agent transcripts:** also add that app reg as a Dataverse **Application User** with read on Conversation Transcript.
-- **+ Credit / Feedback:** an admin exports the CSVs (or schedules a portal export); the flow lands them — no extra API permission.
+- **+ Cost / Feedback:** an admin exports the CSVs (or schedules a portal export); the flow lands them — no extra API permission.
 - **+ Agents 365:** an admin with Reports Reader (+ AI Admin) exports the registry.
 
 See [`README.md`](../README.md) for the step-by-step, and [`OPTIONAL-SOURCES.md`](OPTIONAL-SOURCES.md)


### PR DESCRIPTION
Scopes the four `2. Fabric/docs/` guidance files to the base **No-Studio** build so they only describe what this template actually ships: the three **core** sources (audit logs, licensed users, org data) plus the standard **optional** sources (Agents 365, Product Feedback, Cost Consumption).

Copilot Studio agent-transcript analytics (the `agent_*` Dataverse tables) and PPAC per-agent / per-user message-credit tables are consistently pointed at the separate **Fabric + Copilot Studio** build (`3. Fabric Extended/`) rather than described inline here.

### Files
- **DATA-DICTIONARY.md** — six-row tier table (core + Agents 365 / Product Feedback / Cost Consumption); removed the `agent_*` Dataverse schemas, PPAC per-agent/user credit tables, and the cross-tenant identity section; org join simplified to UPN.
- **INGESTION-STRATEGY.md** — leads with the three core load rules (audit → append; licensed/org → overwrite); removed the transcripts row and Dataverse-path caveat. **Kept** the audit 504/429 retry/resiliency detail and commit-pinning guidance.
- **OPTIONAL-SOURCES.md** — toggle table lists ProductFeedback / Agent365 / CostConsumption only; Studio `Enable_Dataverse` / `Enable_Consumption` toggles demoted to a pointer.
- **PERMISSIONS.md** — dropped the Dataverse transcript permission row; cost row is the MAC Cost management export; Studio (Dataverse Application User / PPAC) grants pointed at the Extended build.

### Not changed
- `README.md` and `INCREMENTAL-REFRESH.md` — already No-Studio-correct.

Docs-only; no model/notebook changes. Byte-identical to the corresponding fork change (Keithland89 PR #105).