### PR TITLE
Fix missing Audit Log Processor in Fabric pipeline

### DIFF
--- a/.github/workflows/sync-shared.yml
+++ b/.github/workflows/sync-shared.yml
@@ -3,6 +3,7 @@ name: sync-shared
 on:
   push:
     paths:
+      - '3. Fabric/pipelines/**'
       - '3. Fabric/notebooks/**'
       - '3. Fabric/extended/**/notebooks/_core/**'
       - '3. Fabric/extended/_shared/notebooks/**'
@@ -12,6 +13,7 @@ on:
       - '.github/workflows/sync-shared.yml'
   pull_request:
     paths:
+      - '3. Fabric/pipelines/**'
       - '3. Fabric/notebooks/**'
       - '3. Fabric/extended/**/notebooks/_core/**'
       - '3. Fabric/extended/_shared/notebooks/**'

--- a/3. Fabric/pipelines/CopilotAdoptionPipeline.DataPipeline/pipeline-content.json
+++ b/3. Fabric/pipelines/CopilotAdoptionPipeline.DataPipeline/pipeline-content.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/pipeline/definition/pipeline/1.0.0/schema.json",
   "properties": {
-    "description": "Orchestrates the Direct Ingester notebooks. Core: Audit log + Licensed Users always run; Org Data is optional via EnableOrgDataPull. Optional sources (Dataverse transcripts, credit consumption, product feedback, Agents 365) are opt-in via their Enable* parameters (default false). Export-only sources (consumption, feedback) require their CSVs to be landed first (manually or via the flows in flows/). See docs/PERMISSIONS.md for roles.",
+    "description": "Orchestrates ingestion followed by the Audit Log Processor, which writes copilot_interactions_curated before semantic-model refresh. Core: Audit log + Licensed Users always run; Org Data is optional via EnableOrgDataPull. The processor waits for audit log, licensed users and the Agents 365 conditional branch to succeed. Optional sources (Dataverse transcripts, credit consumption, product feedback, Agents 365) are opt-in via their Enable* parameters (default false). Export-only sources (consumption, feedback) require their CSVs to be landed first (manually or via the flows in flows/). Semantic-model refresh is scheduled separately after pipeline success. See docs/PERMISSIONS.md for roles.",
     "activities": [
       {
         "name": "Run_Audit_Log_Ingester",
@@ -35,6 +35,37 @@
         },
         "typeProperties": {
           "notebookId": "REPLACE_WITH_LICENSED_USERS_NOTEBOOK_ID",
+          "workspaceId": "REPLACE_WITH_WORKSPACE_ID",
+          "parameters": {}
+        }
+      },
+      {
+        "name": "Run_Audit_Log_Processor",
+        "description": "Transforms copilot_interactions_parsed with licensed-user and available Agents 365 data into copilot_interactions_curated. Waits for the outer Agents 365 condition so disabling that source does not skip processing. Refresh the semantic model only after pipeline success.",
+        "type": "TridentNotebook",
+        "dependsOn": [
+          {
+            "activity": "Run_Audit_Log_Ingester",
+            "dependencyConditions": ["Succeeded"]
+          },
+          {
+            "activity": "Run_Licensed_Users_Ingester",
+            "dependencyConditions": ["Succeeded"]
+          },
+          {
+            "activity": "Conditionally_Run_Agent365",
+            "dependencyConditions": ["Succeeded"]
+          }
+        ],
+        "policy": {
+          "timeout": "0.02:00:00",
+          "retry": 1,
+          "retryIntervalInSeconds": 60,
+          "secureOutput": false,
+          "secureInput": false
+        },
+        "typeProperties": {
+          "notebookId": "REPLACE_WITH_AUDIT_LOG_PROCESSOR_NOTEBOOK_ID",
           "workspaceId": "REPLACE_WITH_WORKSPACE_ID",
           "parameters": {}
         }

--- a/3. Fabric/pipelines/README.md
+++ b/3. Fabric/pipelines/README.md
@@ -1,45 +1,65 @@
 # Fabric pipelines
 
-Scheduled orchestration for the Direct Ingester notebooks. Two ways to use:
+Scheduled orchestration for the Direct Ingester notebooks and the downstream Audit Log Processor.
 
 ## Deployment
 
-1. **Import the 3 notebooks** into your Fabric workspace first (one-time):
+1. **Import the 4 notebooks** into your Fabric workspace first (one-time):
    - `3. Fabric/notebooks/Copilot_Audit_Log_Direct_Ingester.ipynb`
    - `3. Fabric/notebooks/Copilot_Licensed_Users_Direct_Ingester.ipynb`
    - `3. Fabric/notebooks/Copilot_Org_Data_Direct_Ingester.ipynb`
+   - `3. Fabric/notebooks/Copilot_Audit_Log_Processor.ipynb`
 
 2. **Find each notebook's ID** — open the notebook in Fabric, look at the URL:
    ```
    https://app.fabric.microsoft.com/groups/<WORKSPACE_ID>/synapsenotebooks/<NOTEBOOK_ID>?experience=...
                                           ^^^^^^^^^^^^^^                  ^^^^^^^^^^^^
    ```
-   Both GUIDs are visible in the URL. Save them — you'll need 4 GUIDs total (1 workspace + 3 notebooks).
+   Both GUIDs are visible in the URL. Save them — you'll need 5 GUIDs total (1 workspace + 4 notebooks).
 
 3. **Create a new pipeline** in Fabric:
    - Workspace → **+ New** → **Data pipeline** → name it `CopilotAdoptionPipeline`
    - Use the JSON view (toolbar → **View** → **JSON** or "Code") and paste the contents of [`CopilotAdoptionPipeline.DataPipeline/pipeline-content.json`](CopilotAdoptionPipeline.DataPipeline/pipeline-content.json)
    - Replace the placeholder values:
      - `REPLACE_WITH_AUDIT_LOG_NOTEBOOK_ID` → your audit-log notebook GUID
+     - `REPLACE_WITH_AUDIT_LOG_PROCESSOR_NOTEBOOK_ID` → your audit-log processor notebook GUID
      - `REPLACE_WITH_LICENSED_USERS_NOTEBOOK_ID` → your users notebook GUID
      - `REPLACE_WITH_ORG_DATA_NOTEBOOK_ID` → your org-data notebook GUID
      - `REPLACE_WITH_WORKSPACE_ID` → your workspace GUID (used by every activity)
      - *(Only if you turn optional sources on)* the optional notebook GUIDs — see [Optional sources](#optional-sources-opt-in) below. Leave them as placeholders if unused; they never run while their toggle is `false`.
    - Save
 
-4. **Run manually first** to validate: pipeline editor → **Run** at top. Should kick off the 3 notebooks in parallel. Audit log activity typically runs 5–15 min (Purview polling); users + org each <30 sec.
+4. **Run manually first** to validate: pipeline editor → **Run** at top. The 3 ingesters start in parallel (Org Data only when enabled). Audit log ingestion typically runs 5–15 min (Purview polling); users + org each <30 sec. The processor then runs after audit-log ingestion, licensed-users ingestion and the Agents 365 conditional branch succeed, writing `copilot_interactions_curated`. Processor runtime depends on data volume and Spark startup.
 
 5. **Schedule it**: pipeline editor → **Schedule** at top → e.g. weekly Sunday 02:00. Activities run on the same cadence.
 
+6. **Refresh the semantic model only after pipeline success.** This template does not include a semantic-model refresh activity. If you add one, make it wait for the processor and all other enabled model sources to succeed; a fixed-time refresh alone does not guarantee ingestion and processing have finished.
+
+**Existing deployments:** import the processor notebook, add `Run_Audit_Log_Processor` from the updated JSON (including its `dependsOn` entries), and replace its notebook/workspace placeholders with your IDs. Preserve your existing activity IDs and parameter settings. Updating this repository does not automatically update a manually imported Fabric pipeline.
+
 ## Activity design notes
 
-| Activity | Runtime | Why it's parallel-safe |
+| Activity | Runtime | Dependencies and output |
 |---|---|---|
 | `Run_Audit_Log_Ingester` | 5–15 min (Purview-bound) | Reads Graph audit log API; writes to `dbo.copilot_interactions_parsed`. No dependency on other tables. |
 | `Run_Licensed_Users_Ingester` | <30 sec | Reads Graph reports endpoint; writes to `dbo.copilot_licensed_users`. No dependency on audit log. |
 | `Conditionally_Run_Org_Data` → `Run_Org_Data_Ingester` | <30 sec when enabled | Reads Graph users endpoint; writes to `dbo.copilot_org_data`. **Optional** — gated by the `EnableOrgDataPull` parameter. |
+| `Run_Audit_Log_Processor` | Depends on data volume / Spark startup | Reads `copilot_interactions_parsed`, `copilot_licensed_users` and available `agents_365`; writes `copilot_interactions_curated`. Runs only after its three upstream dependencies succeed. |
 
-Since the 3 tables are independent (joined later at the model layer in the PBIT), the activities can run in parallel for fastest total runtime ≈ max(audit, users, org) ≈ 15 min vs sequential ≈ 16 min. Tiny gain, but cleaner conceptually.
+The ingesters remain parallel. The processor is a downstream transform, not another ingester:
+
+```text
+Run_Audit_Log_Ingester -------+
+Run_Licensed_Users_Ingester --+--> Run_Audit_Log_Processor --> curated table
+Conditionally_Run_Agent365 --+
+```
+
+The processor depends on the **outer** `Conditionally_Run_Agent365` activity, not its nested notebook.
+With `EnableAgent365 = false`, the empty false branch succeeds and processing can continue; with it
+enabled, processing waits for the lander to succeed. The processor can use an existing `agents_365`
+table when the pull is disabled, or handle its absence as documented in the notebook. Org Data and
+the other optional sources are not processor inputs, so they have no dependency edge to it.
+Total runtime now includes the downstream processing stage.
 
 ## Pipeline parameters
 
@@ -71,13 +91,17 @@ To switch one on: set its parameter to `true` **and** replace its notebook GUID 
 > *before* this pipeline (or land the files by hand), otherwise the ingester finds nothing and writes
 > an empty table.
 
-All optional activities run in parallel with the core ones (no cross-dependencies) and follow the
-same `Enable*` naming as the PBIT's model toggles, so "on in the pipeline" lines up with "on in the report".
+All optional ingestion branches start in parallel with the core ingesters. The processor waits
+for the Agents 365 conditional branch only; the other optional branches remain independent.
+The toggles follow the same `Enable*` naming as the PBIT's model toggles, so "on in the pipeline"
+lines up with "on in the report".
 
 ## Failure handling
 
-- Each activity has `retry: 1` (audit log) or `retry: 2` (users/org) at 60s intervals — handles transient Graph throttling
+- Audit ingestion and processing each have `retry: 1`; users/org have `retry: 2`, all at 60s intervals. Ingestion retries handle transient Graph throttling; processor retries rerun the transform.
 - If audit log fails after retry, users + org still complete (parallel branches don't block each other)
+- If audit ingestion, licensed-users ingestion or the Agents 365 condition fails, the processor is skipped. Do not refresh the model against an old curated table after such a run.
+- If the processor fails, ingestion outputs remain available but the pipeline has not produced a successful curated-data update. Resolve the failure before refreshing the model.
 - If any single activity ultimately fails, the pipeline run is marked failed but partial Delta writes are preserved
 - Use Fabric Monitor Hub → Pipeline runs → click into the failed activity → view notebook job log for diagnostics
 
@@ -91,4 +115,6 @@ Microsoft Graph's audit log API caps each query at 7 days back. Recommended sche
 | Daily | 02:00 UTC | More frequent updates; needs careful date-window management to avoid duplicate rows (the audit log Message_Id dedup mostly handles this) |
 | Monthly | Last day of month | Misses any 8th+ day of data — only use if you accept this |
 
-The 3 activities can share the same schedule, or you can give users + org a different (slower) cadence since they snapshot quickly-changing data less often.
+Schedule the pipeline as one ingestion-and-processing unit, then refresh the semantic model after
+successful completion. If you customize ingestion cadences, preserve the processor's dependencies
+so it runs only after its required source tables are ready.

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,100 @@
+"""Offline checks for the published pipeline's processor dependency contract."""
+import json
+import re
+import unittest
+from graphlib import TopologicalSorter
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PIPELINES = ROOT / "3. Fabric" / "pipelines"
+PROCESSOR = "Run_Audit_Log_Processor"
+INPUTS = {
+    "Run_Audit_Log_Ingester",
+    "Run_Licensed_Users_Ingester",
+    "Conditionally_Run_Agent365",
+}
+
+
+class PipelineTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        path = PIPELINES / "CopilotAdoptionPipeline.DataPipeline" / "pipeline-content.json"
+        cls.definition = json.loads(path.read_text(encoding="utf-8"))
+        cls.properties = cls.definition["properties"]
+        cls.activities = {a["name"]: a for a in cls.properties["activities"]}
+
+    def test_processor_is_a_required_notebook_with_deployment_placeholders(self):
+        processor = self.activities[PROCESSOR]
+        self.assertEqual(processor["type"], "TridentNotebook")
+        self.assertEqual(processor["typeProperties"], {
+            "notebookId": "REPLACE_WITH_AUDIT_LOG_PROCESSOR_NOTEBOOK_ID",
+            "workspaceId": "REPLACE_WITH_WORKSPACE_ID",
+            "parameters": {},
+        })
+        self.assertEqual(processor.get("state", "Active"), "Active")
+        self.assertEqual(processor["policy"]["timeout"], "0.02:00:00")
+        self.assertEqual(processor["policy"]["retry"], 1)
+        self.assertTrue(
+            (ROOT / "3. Fabric" / "notebooks" / "Copilot_Audit_Log_Processor.ipynb").is_file()
+        )
+
+    def test_processor_waits_for_all_and_only_its_input_producers_to_succeed(self):
+        dependencies = self.activities[PROCESSOR]["dependsOn"]
+        self.assertEqual(len(dependencies), len(INPUTS))
+        self.assertEqual({d["activity"] for d in dependencies}, INPUTS)
+        for dependency in dependencies:
+            self.assertEqual(dependency["dependencyConditions"], ["Succeeded"])
+
+    def test_agent365_disabled_branch_allows_outer_condition_to_complete(self):
+        condition = self.activities["Conditionally_Run_Agent365"]
+        self.assertEqual(condition["type"], "IfCondition")
+        self.assertIs(self.properties["parameters"]["EnableAgent365"]["defaultValue"], False)
+        self.assertEqual(condition["typeProperties"]["expression"], {
+            "value": "@pipeline().parameters.EnableAgent365",
+            "type": "Expression",
+        })
+        self.assertEqual(condition["typeProperties"]["ifFalseActivities"], [])
+        enabled = condition["typeProperties"]["ifTrueActivities"]
+        self.assertEqual(len(enabled), 1)
+        self.assertEqual(enabled[0]["name"], "Run_Agent365_Lander")
+        self.assertEqual(enabled[0]["type"], "TridentNotebook")
+        dependencies = {d["activity"] for d in self.activities[PROCESSOR]["dependsOn"]}
+        self.assertIn(condition["name"], dependencies)
+        self.assertNotIn(enabled[0]["name"], dependencies)
+
+    def test_graph_is_acyclic_and_all_dependencies_resolve_at_top_level(self):
+        self.assertEqual(len(self.activities), len(self.properties["activities"]))
+        graph = {}
+        for name, activity in self.activities.items():
+            graph[name] = {d["activity"] for d in activity["dependsOn"]}
+            self.assertTrue(graph[name] <= self.activities.keys())
+        order = list(TopologicalSorter(graph).static_order())
+        for source in INPUTS:
+            self.assertLess(order.index(source), order.index(PROCESSOR))
+
+    def test_ingestion_branches_remain_parallel_and_optional_defaults_unchanged(self):
+        for name, activity in self.activities.items():
+            if name != PROCESSOR:
+                self.assertEqual(activity["dependsOn"], [], name)
+        self.assertEqual(
+            {name: p["defaultValue"] for name, p in self.properties["parameters"].items()},
+            {
+                "EnableOrgDataPull": True,
+                "EnableDataverse": False,
+                "EnableConsumption": False,
+                "EnableProductFeedback": False,
+                "EnableAgent365": False,
+            },
+        )
+
+    def test_readme_documents_all_placeholders_and_refresh_handoff(self):
+        readme = (PIPELINES / "README.md").read_text(encoding="utf-8")
+        for placeholder in set(re.findall(r"REPLACE_WITH_[A-Z_]+", json.dumps(self.definition))):
+            self.assertIn(placeholder, readme)
+        self.assertIn("Import the 4 notebooks", readme)
+        self.assertIn("5 GUIDs total", readme)
+        self.assertIn("Refresh the semantic model only after pipeline success", readme)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add processor success dependencies on audit ingestion, licensed users,
and the outer Agent365 condition. Update deployment instructions and
add pipeline regression coverage with CI triggers.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>